### PR TITLE
feat(api): remove state requirement from requests

### DIFF
--- a/src/main/java/com/example/checkers/api/GameController.java
+++ b/src/main/java/com/example/checkers/api/GameController.java
@@ -36,10 +36,6 @@ public class GameController implements GameApi {
         return ok(gameService.getGamesByProgress(progress));
     }
 
-    private void validateProgress(List<String> progress) {
-        progress.forEach(GameProgress::valueOf);
-    }
-
     @Override
     public ResponseEntity<GameResponse> startLobby(StartLobbyRequest request) {
         String side = request.getSide();
@@ -57,4 +53,10 @@ public class GameController implements GameApi {
         gameService.lobbyExistsAndPlayerIsDifferent(gameId, playerId);
         return ok(gameService.startGame(gameId, playerId));
     }
+
+    //region private methods
+    private void validateProgress(List<String> progress) {
+        progress.forEach(GameProgress::valueOf);
+    }
+    //endregion
 }

--- a/src/main/java/com/example/checkers/api/MoveController.java
+++ b/src/main/java/com/example/checkers/api/MoveController.java
@@ -5,11 +5,16 @@ import com.example.checkers.model.MoveRequest;
 import com.example.checkers.model.MoveResponse;
 import com.example.checkers.service.GameService;
 import com.example.checkers.service.MoveService;
+import com.example.checkers.service.MoveValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RestController;
 
+import static org.springframework.http.ResponseEntity.badRequest;
 import static org.springframework.http.ResponseEntity.ok;
 
 @CrossOrigin(origins = {"http://localhost:5173", "http://localhost:5174"})
@@ -20,6 +25,8 @@ public class MoveController implements MoveApi {
     private final GameService gameService;
 
     private final MoveService moveService;
+
+    private final MoveValidator validator;
 
     @Override
     public ResponseEntity<MoveResponse> getCurrentState(String gameId) {
@@ -32,9 +39,29 @@ public class MoveController implements MoveApi {
 
     @Override
     public ResponseEntity<MoveResponse> move(String gameId, MoveRequest moveRequest) {
+        Errors errors = new BeanPropertyBindingResult(moveRequest, "move");
+        validator.validate(moveRequest, errors);
+        if (errors.hasErrors()) {
+            return generateErrorResponse(errors);
+        }
         MoveResponse moveResponse = moveService.saveMove(
                 gameId, moveRequest
         );
         return ok(moveResponse);
+    }
+
+
+
+
+
+
+
+
+
+
+    private ResponseEntity<MoveResponse> generateErrorResponse(Errors errors) {
+        MoveResponse moveResponse = new MoveResponse();
+        moveResponse.setErrors(errors.getAllErrors());
+        return badRequest().body(moveResponse);
     }
 }

--- a/src/main/java/com/example/checkers/service/MoveValidator.java
+++ b/src/main/java/com/example/checkers/service/MoveValidator.java
@@ -1,0 +1,57 @@
+package com.example.checkers.service;
+
+import com.example.checkers.domain.Checkerboard;
+import com.example.checkers.domain.PossibleMove;
+import com.example.checkers.domain.Side;
+import com.example.checkers.model.MoveRequest;
+import com.example.checkers.persistence.MoveRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.ValidationUtils;
+import org.springframework.validation.Validator;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class MoveValidator implements Validator {
+
+    private final MoveRepository moveRepository;
+
+    private PossibleMoveProvider possibleMoveProvider;
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return clazz.equals(MoveRequest.class);
+    }
+
+    @Override
+    public void validate(Object target, Errors errors) {
+        MoveRequest moveRequest = (MoveRequest) target;
+        var moves = moveRepository.findAllByGameId(moveRequest.getGameId());
+        var lastMove = moves.getLast();
+        var possibleMoves = possibleMoveProvider.getPossibleMovesMap(
+                Side.valueOf(lastMove.getSide()), Checkerboard.state(
+                        Arrays.stream(lastMove.getDark().split(",")).map(Integer::valueOf).toList(),
+                        Arrays.stream(lastMove.getLight().split(",")).map(Integer::valueOf).toList()
+                ));
+        String start = moveRequest.getMove().split("x\\-")[0];
+        String end = moveRequest.getMove().split("x\\-")[1];
+        List<PossibleMove> movesByStart = possibleMoves.get(Integer.valueOf(start)).stream()
+                .filter(m -> m.destination() == Integer.parseInt(end))
+                .toList();
+
+        Set<String> possibleMovesSet = movesByStart.stream()
+                .map(m -> start + (m.isCapture() ? "x" : "-") + m.destination())
+                .collect(Collectors.toSet());
+
+
+        if (!possibleMovesSet.contains(moveRequest.getMove())) {
+            ValidationUtils.rejectIfEmpty(errors, "move", "impossible.move");
+        }
+    }
+}

--- a/src/main/java/com/example/checkers/service/PossibleMoveProvider.java
+++ b/src/main/java/com/example/checkers/service/PossibleMoveProvider.java
@@ -10,8 +10,26 @@ import java.util.*;
 @Component
 public class PossibleMoveProvider {
 
-    List<PossibleMove> getPossibleMoves(int num, Side side, Checkerboard state,
-                                        boolean isCaptureTerminalityCheck) {
+    Map<Integer, List<PossibleMove>> getPossibleMovesMap(Side side, Checkerboard state) {
+        var map = new HashMap<Integer, List<PossibleMove>>();
+        // TODO refactor possible moves representation
+        for (int i : state.getSide(side)) {
+            List<PossibleMove> possibleMoves = getPossibleMoves(i, side, state);
+            if (!possibleMoves.isEmpty()) {
+                map.put(i, possibleMoves);
+            }
+        }
+        return map;
+    }
+
+
+    public List<PossibleMove> getPossibleMoves(int num, Side side, Checkerboard state) {
+        return getPossibleMoves(num, side, state, false);
+    }
+
+    // region private methods
+    public List<PossibleMove> getPossibleMoves(int num, Side side, Checkerboard state,
+                                               boolean isCaptureTerminalityCheck) {
 
         List<LinkedList<Integer>> board = Checkerboard.getDiagonals();
 
@@ -46,23 +64,6 @@ public class PossibleMoveProvider {
             return captureMoves;
         }
         return captureMovesVerifiedForTerminality(state, side, captureMoves);
-    }
-
-
-    List<PossibleMove> getPossibleMoves(int num, Side side, Checkerboard state) {
-        return getPossibleMoves(num, side, state, false);
-    }
-
-    Map<Integer, List<PossibleMove>> getPossibleMovesMap(Side side, Checkerboard state) {
-        var map = new HashMap<Integer, List<PossibleMove>>();
-        // TODO refactor possible moves representation
-        for (int i : state.getSide(side)) {
-            List<PossibleMove> possibleMoves = getPossibleMoves(i, side, state);
-            if (!possibleMoves.isEmpty()) {
-                map.put(i, possibleMoves);
-            }
-        }
-        return map;
     }
 
     private List<PossibleMove> captureMovesVerifiedForTerminality(Checkerboard state,
@@ -151,4 +152,5 @@ public class PossibleMoveProvider {
         }
         return Optional.empty();
     }
+    //endregion
 }

--- a/src/main/resources/openapi/components/responses.yaml
+++ b/src/main/resources/openapi/components/responses.yaml
@@ -28,6 +28,8 @@ MoveResponse:
       $ref: './schemas.yaml#/State'
     side:
       type: string
+    errors:
+      type: array
     possibleMoves:
       schema:
         type: array

--- a/src/main/resources/openapi/components/schemas.yaml
+++ b/src/main/resources/openapi/components/schemas.yaml
@@ -1,12 +1,12 @@
 MoveRequest:
   type: object
   properties:
+    gameId:
+      type: string
     side:
       type: string
     move:
       type: string
-    state:
-      $ref: '#/State'
     playerId:
       type: integer
       format: int64

--- a/src/test/java/com/example/checkers/service/MoveServiceImplTest.java
+++ b/src/test/java/com/example/checkers/service/MoveServiceImplTest.java
@@ -95,7 +95,6 @@ class MoveServiceImplTest {
         );
 
         MoveRequest moveRequest = new MoveRequest();
-        moveRequest.setState(currentState);
         moveRequest.setMove("15x22");
         moveRequest.setSide(Side.DARK.name());
         moveRequest.setPlayerId(2L);
@@ -114,7 +113,6 @@ class MoveServiceImplTest {
         );
 
         moveRequest = new MoveRequest();
-        moveRequest.setState(currentState);
         moveRequest.setMove("14x21");
         moveRequest.setSide(Side.DARK.name());
         moveRequest.setPlayerId(1L);


### PR DESCRIPTION
The initial idea behind sending the state was to verify a request - is the move we are going to perform adheres to the previously saved state? By doing this we ensure the consistency of the game. However, sending state each time is redundant - it is enough for the frontend to send the move only, and the backend could deduce - is the move valid, according to the latest move saved in the database? 

However(again!), it is possible that different moves are valid across different states. So, maybe it makes sense to always send the state? 