### PR TITLE
Fix playerId parameter name and spec

### DIFF
--- a/src/main/java/com/example/checkers/service/GameStateService.java
+++ b/src/main/java/com/example/checkers/service/GameStateService.java
@@ -24,5 +24,5 @@ public interface GameStateService {
 
   boolean isGameInProgressConsistent(UUID gameId, MoveRequest moveRequest);
 
-  GameResponse startImportedGameLobby(Long playedId, String side, State state);
+  GameResponse startImportedGameLobby(Long playerId, String side, State state);
 }

--- a/src/main/resources/openapi/paths/game.yaml
+++ b/src/main/resources/openapi/paths/game.yaml
@@ -44,7 +44,7 @@ post:
         schema:
           type: object
           required:
-            - playedId
+            - playerId
             - side
           properties:
             playerId:


### PR DESCRIPTION
## Summary
- fix OpenAPI spec to require `playerId`
- rename `playedId` parameter to `playerId` in `GameStateService`

## Testing
- `./gradlew openApiGenerate --no-daemon` *(fails: Unable to tunnel through proxy)*
- `./gradlew build -x test` *(fails: Unable to tunnel through proxy)*


------
https://chatgpt.com/codex/tasks/task_e_684212e3c178832080fc613a665ef7ab