### PR TITLE
Improve assertion in PossibleMoveServiceImplTest

### DIFF
--- a/src/test/java/com/example/checkers/service/PossibleMoveServiceImplTest.java
+++ b/src/test/java/com/example/checkers/service/PossibleMoveServiceImplTest.java
@@ -107,9 +107,14 @@ class PossibleMoveServiceImplTest {
     when(turnService.getWhichSideToMove(game.getId())).thenReturn(Side.DARK);
 
     MoveResponse moveResponse = moveService.getNextMoves(gameId);
-    assertEquals(
-        "{13=[PossibleMoveSimplified[position=13, destination=22, isCapture=true]]}",
-        moveResponse.getPossibleMoves().toString());
+
+    Map<Integer, List<PossibleMoveSimplified>> expected = new HashMap<>();
+    expected.put(13, List.of(new PossibleMoveSimplified(13, 22, true)));
+
+    Map<Integer, List<PossibleMoveSimplified>> actual =
+        (Map<Integer, List<PossibleMoveSimplified>>) moveResponse.getPossibleMoves();
+
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- build a map of expected moves in `givenMoveResultsInCapture_whenMove_returnValidState`
- assert equality using AssertJ instead of comparing strings

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6842162280c4832090d9893786d5e693