### PR TITLE
Fix enum value in game spec

### DIFF
--- a/src/main/resources/openapi/paths/game.yaml
+++ b/src/main/resources/openapi/paths/game.yaml
@@ -12,7 +12,7 @@ get:
         type: array
         items:
           type: string
-          enum: [ LOBBY, STARTING, ONGOING, COMPLETED, ARCHIVED ]
+          enum: [ LOBBY, STARTING, ONGOING, FINISHED, ARCHIVED ]
   responses:
     '200':
       description: Successful operation


### PR DESCRIPTION
## Summary
- update the games path specification enum from `COMPLETED` to `FINISHED`

## Testing
- `gradle openApiValidate` *(fails: Plugin [id: 'org.springframework.boot', version: '3.1.3'] was not found)*
- `gradle openApiGenerate` *(fails: Plugin [id: 'org.springframework.boot', version: '3.1.3'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842160bb3e88320b0b3ba1f98a5b39e